### PR TITLE
Mail should only queue once handler returns without error

### DIFF
--- a/smtpd.go
+++ b/smtpd.go
@@ -29,7 +29,7 @@ var (
 )
 
 // Handler function called upon successful receipt of an email.
-type Handler func(remoteAddr net.Addr, from string, to []string, data []byte)
+type Handler func(remoteAddr net.Addr, from string, to []string, data []byte) error
 
 // HandlerRcpt function called on RCPT. Return accept status.
 type HandlerRcpt func(remoteAddr net.Addr, from string, to string) bool
@@ -379,12 +379,16 @@ loop:
 			buffer.Reset()
 			buffer.Write(s.makeHeaders(to))
 			buffer.Write(data)
-			s.writef("250 2.0.0 Ok: queued")
 
 			// Pass mail on to handler.
 			if s.srv.Handler != nil {
-				go s.srv.Handler(s.conn.RemoteAddr(), from, to, buffer.Bytes())
+				err := s.srv.Handler(s.conn.RemoteAddr(), from, to, buffer.Bytes())
+				if err != nil {
+					s.writef("451 4.3.5 Unable to process mail")
+					break
+				}
 			}
+			s.writef("250 2.0.0 Ok: queued")
 
 			// Reset for next mail.
 			from = ""


### PR DESCRIPTION
The purpose of this PR is to allow messages to be processed safely before the client receives a '250 Ok' response. If the mail handler returns an error then a 4xx code is sent to the client instead, at which point it is up to the client to try again later. Without this, a message is lost if the mail handler fails to process the message. For example, if the mail handler is responsible for persisting messages, but fails, then the message wasn't actually queued and the message is lost forever.

I've also renamed Handler to MailHandler for consistency with AuthHandler (HandlerRcpt should ideally be renamed as well) and I've added in tests for the mail handler.