### PR TITLE
Allow space after FROM: as some (broken) clients do this

### DIFF
--- a/smtpd.go
+++ b/smtpd.go
@@ -23,7 +23,7 @@ import (
 var (
 	// Debug `true` enables verbose logging.
 	Debug      = false
-	rcptToRE   = regexp.MustCompile(`[Tt][Oo]:\s?<(.+)>`)
+	rcptToRE   = regexp.MustCompile(`[Tt][Oo]:<(.+)>`)
 	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\s?<(.*)>(\s(.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
 	mailSizeRE = regexp.MustCompile(`[Ss][Ii][Zz][Ee]=(\d+)`)
 )

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -84,6 +84,8 @@ func TestCmdHELO(t *testing.T) {
 	// Verify that HELO resets the current transaction state like RSET.
 	// RFC 2821 section 4.1.4 says EHLO should cause a reset, so verify that HELO does it too.
 	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	// Some clients add a space after the :
+	cmdCode(t, conn, "MAIL FROM: <sender@example.com>", "250")
 	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
 	cmdCode(t, conn, "HELO host.example.com", "250")
 	cmdCode(t, conn, "DATA", "503")


### PR DESCRIPTION
I've found a couple of mail clients that add an extra space after `FROM:`, this patch allows this optional space.