### PR TITLE
Add listener tracking and listener closing on close/shutdown

### DIFF
--- a/smtpd.go
+++ b/smtpd.go
@@ -713,7 +713,7 @@ func (s *session) readData() ([]byte, error) {
 func (s *session) makeHeaders(to []string) []byte {
 	var buffer bytes.Buffer
 	now := time.Now().Format("Mon, _2 Jan 2006 15:04:05 -0700 (MST)")
-	buffer.WriteString(fmt.Sprintf("Received: from %s (%s [%s])\r\n", s.remoteName, s.remoteHost, s.remoteIP))
+	buffer.WriteString(fmt.Sprintf("Received: from %s\r\n", s.remoteName))
 	buffer.WriteString(fmt.Sprintf("        by %s (%s) with SMTP\r\n", s.srv.Hostname, s.srv.Appname))
 	buffer.WriteString(fmt.Sprintf("        for <%s>; %s\r\n", to[0], now))
 	return buffer.Bytes()


### PR DESCRIPTION
In relation to #27, here's my attempt to fix server shutdown of an idle server.

I looked at `net.http` and used the same approach. I copied `trackListener` and `closeListeners` from `net.http` almost as-is (added a note in README about it). 

The idea:

* `ln.Accept()` is blocking. To make it return, we close the listener. 
* `Serve()` takes a listener parameter, and the server in principle can have multiple listeners in use. Server must keep track of the listeners, so it can close them on shutdown. That's what `srv.listeners` and `trackListener` does.

This PR needs a review. I'm new to Go, and would not be aware of any subtle bugs this may be introducing.

One particular thing I'm not sure about is the listener closing function. In `net.http`, it is called "closeListenersLocked". The "Locked" part must have some significance, but I'm not sure what exactly. In general, I suspect the Close and Shutdown methods may have thread safety problems.