### PR TITLE
Implemented context-aware handlers to smtpd for session metadata and state sharing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mhale/smtpd
+module github.com/uksarkar/smtpd
 
-go 1.14
+go 1.24

--- a/smtpd.go
+++ b/smtpd.go
@@ -1106,7 +1106,7 @@ func (s *session) handleAuthPlain(arg string) (bool, error) {
 	}
 
 	s.c.auth = &Auth{
-		Mechanism: AuthLogin,
+		Mechanism: AuthPlain,
 		Username:  parts[1],
 		Password:  parts[2],
 	}

--- a/smtpd.go
+++ b/smtpd.go
@@ -796,14 +796,18 @@ loop:
 
 			// RFC 4954 requires a mechanism parameter.
 			authType, authArgs := s.parseLine(args)
-			authMach, ok := parseAuthMech(authType)
-
-			if !ok {
+			if authType == "" {
 				s.writef("501 5.5.4 Malformed AUTH input (argument required)")
 				break
 			}
 
 			// RFC 4954 requires rejecting unsupported authentication mechanisms with a 504 response.
+			authMach, ok := parseAuthMech(authType)
+			if !ok {
+				s.writef("504 5.5.4 Unrecognized authentication type")
+				break
+			}
+
 			allowedAuth := s.authMechs()
 			if allowed, found := allowedAuth[authMach]; !found || !allowed {
 				s.writef("504 5.5.4 Unrecognized authentication type")

--- a/smtpd.go
+++ b/smtpd.go
@@ -31,16 +31,16 @@ var (
 	mailSizeRE = regexp.MustCompile(`[Ss][Ii][Zz][Ee]=(\d+)`)
 )
 
-type AuthMach int
+type AuthMech int
 
 const (
-	AuthNone AuthMach = iota
+	AuthNone AuthMech = iota
 	AuthPlain
 	AuthLogin
 	AuthCramMD5
 )
 
-func (a AuthMach) String() string {
+func (a AuthMech) String() string {
 	switch a {
 	case AuthPlain:
 		return "PLAIN"
@@ -53,30 +53,37 @@ func (a AuthMach) String() string {
 	}
 }
 
+func parseAuthMech(s string) (AuthMech, bool) {
+	switch strings.ToUpper(s) {
+	case "PLAIN":
+		return AuthPlain, true
+	case "LOGIN":
+		return AuthLogin, true
+	case "CRAM-MD5":
+		return AuthCramMD5, true
+	case "NONE":
+		return AuthNone, true
+	default:
+		return AuthNone, false
+	}
+}
+
 // Handler function called upon successful receipt of an email.
 // Results in a "250 2.0.0 Ok: queued" response.
-type Handler func(remoteAddr net.Addr, from string, to []string, data []byte) error
-
-type HandlerWithCtx func(ctx *Context, msg Message) error
+type Handler func(ctx *Context, msg Message) error
 
 // MsgIDHandler function called upon successful receipt of an email. Returns a message ID.
 // Results in a "250 2.0.0 Ok: queued as <message-id>" response.
-type MsgIDHandler func(remoteAddr net.Addr, from string, to []string, data []byte) (string, error)
-
-type MsgIDHandlerWithCtx func(ctx *Context, msg Message) (string, error)
+type MsgIDHandler func(ctx *Context, msg Message) (string, error)
 
 // HandlerRcpt function called on RCPT. Return accept status.
-type HandlerRcpt func(remoteAddr net.Addr, from string, to string) bool
-
-type HandlerRcptWithCtx func(ctx *Context, from string, to string) bool
+type HandlerRcpt func(ctx *Context, from string, to string) bool
 
 // AuthHandler function called when a login attempt is performed. Returns true if credentials are correct.
-type AuthHandler func(remoteAddr net.Addr, mechanism string, username []byte, password []byte, shared []byte) (bool, error)
-
-type AuthHandlerWithCtx func(ctx *Context) (bool, error)
+type AuthHandler func(ctx *Context) (bool, error)
 
 type Auth struct {
-	Mechanism AuthMach
+	Mechanism AuthMech
 	Username  []byte
 	Password  []byte
 	Shared    []byte // This field is used exclusively with the "CRAM-MD5" authentication mechanism.
@@ -129,28 +136,24 @@ type LogFunc func(remoteIP, verb, line string)
 
 // Server is an SMTP server.
 type Server struct {
-	Addr                string // TCP address to listen on, defaults to ":25" (all addresses, port 25) if empty
-	Appname             string
-	AuthHandler         AuthHandler
-	AuthHandlerWithCtx  AuthHandlerWithCtx
-	AuthMechs           map[string]bool // Override list of allowed authentication mechanisms. Currently supported: LOGIN, PLAIN, CRAM-MD5. Enabling LOGIN and PLAIN will reduce RFC 4954 compliance.
-	AuthRequired        bool            // Require authentication for every command except AUTH, EHLO, HELO, NOOP, RSET or QUIT as per RFC 4954. Ignored if AuthHandler is not configured.
-	DisableReverseDNS   bool            // Disable reverse DNS lookups, enforces "unknown" hostname
-	Handler             Handler
-	HandlerWithCtx      HandlerWithCtx
-	HandlerRcpt         HandlerRcpt
-	HandlerRcptWithCtx  HandlerRcptWithCtx
-	Hostname            string
-	LogRead             LogFunc
-	LogWrite            LogFunc
-	MaxSize             int // Maximum message size allowed, in bytes
-	MaxRecipients       int // Maximum number of recipients, defaults to 100.
-	MsgIDHandler        MsgIDHandler
-	MsgIDHandlerWithCtx MsgIDHandlerWithCtx
-	Timeout             time.Duration
-	TLSConfig           *tls.Config
-	TLSListener         bool // Listen for incoming TLS connections only (not recommended as it may reduce compatibility). Ignored if TLS is not configured.
-	TLSRequired         bool // Require TLS for every command except NOOP, EHLO, STARTTLS, or QUIT as per RFC 3207. Ignored if TLS is not configured.
+	Addr              string // TCP address to listen on, defaults to ":25" (all addresses, port 25) if empty
+	Appname           string
+	AuthHandler       AuthHandler
+	AuthMechs         map[AuthMech]bool // Override list of allowed authentication mechanisms. Currently supported: LOGIN, PLAIN, CRAM-MD5. Enabling LOGIN and PLAIN will reduce RFC 4954 compliance.
+	AuthRequired      bool              // Require authentication for every command except AUTH, EHLO, HELO, NOOP, RSET or QUIT as per RFC 4954. Ignored if AuthHandler is not configured.
+	DisableReverseDNS bool              // Disable reverse DNS lookups, enforces "unknown" hostname
+	Handler           Handler
+	HandlerRcpt       HandlerRcpt
+	Hostname          string
+	LogRead           LogFunc
+	LogWrite          LogFunc
+	MaxSize           int // Maximum message size allowed, in bytes
+	MaxRecipients     int // Maximum number of recipients, defaults to 100.
+	MsgIDHandler      MsgIDHandler
+	Timeout           time.Duration
+	TLSConfig         *tls.Config
+	TLSListener       bool // Listen for incoming TLS connections only (not recommended as it may reduce compatibility). Ignored if TLS is not configured.
+	TLSRequired       bool // Require TLS for every command except NOOP, EHLO, STARTTLS, or QUIT as per RFC 3207. Ignored if TLS is not configured.
 
 	inShutdown   int32 // server was closed or shutdown
 	openSessions int32 // count of open sessions
@@ -160,65 +163,8 @@ type Server struct {
 	XClientAllowed []string // List of XCLIENT allowed IP addresses
 }
 
-// handleAuth executes the server's authentication handler.
-// If AuthHandler is set, it is called with the connection details.
-// Otherwise, AuthHandlerWithCtx is invoked.
-func (srv *Server) handleAuth(c *Context) (bool, error) {
-	if srv.AuthHandler != nil {
-		return srv.AuthHandler(c.remoteAddr, c.Mechanism().String(), c.Username(), c.Username(), c.Shared())
-	}
-
-	return srv.AuthHandlerWithCtx(c)
-}
-
-// handle dispatches the message to the server's handler.
-// If Handler is set, it is invoked directly; otherwise HandlerWithCtx is used.
-func (srv *Server) handle(c *Context, m Message) error {
-	if srv.Handler != nil {
-		return srv.Handler(c.remoteAddr, m.From, m.To, m.Data)
-	}
-
-	return srv.HandlerWithCtx(c, m)
-}
-
-// handleMsgId generates a message ID using the server's handler.
-// If MsgIDHandler is set, it is called directly; otherwise MsgIDHandlerWithCtx is used.
-func (srv *Server) handleMsgId(c *Context, m Message) (string, error) {
-	if srv.MsgIDHandler != nil {
-		return srv.MsgIDHandler(c.remoteAddr, m.From, m.To, m.Data)
-	}
-
-	return srv.MsgIDHandlerWithCtx(c, m)
-}
-
-// handleRcpt validates a recipient using the server's handler.
-// If HandlerRcpt is set, it is called directly; otherwise HandlerRcptWithCtx is used.
-func (srv *Server) handleRcpt(c *Context, from string, to string) bool {
-	if srv.HandlerRcpt != nil {
-		return srv.HandlerRcpt(c.remoteAddr, from, to)
-	}
-
-	return srv.HandlerRcptWithCtx(c, from, to)
-}
-
-// hasAuthHandler reports whether an authentication handler is configured.
 func (srv *Server) hasAuthHandler() bool {
-	return srv.AuthHandler != nil || srv.AuthHandlerWithCtx != nil
-}
-
-// hasHandler reports whether a message handler is configured.
-func (srv *Server) hasHandler() bool {
-	return srv.Handler != nil || srv.HandlerWithCtx != nil
-}
-
-// hasMsgIdHandler reports whether a message ID handler is configured.
-func (srv *Server) hasMsgIdHandler() bool {
-	return srv.MsgIDHandler != nil || srv.MsgIDHandlerWithCtx != nil
-}
-
-// hasRcptHandler reports whether a recipient handler is configured.
-func (srv *Server) hasRcptHandler() bool {
-	return srv.HandlerRcpt != nil || srv.HandlerRcptWithCtx != nil
+	return srv.AuthHandler != nil
 }
 
 // requiredAuth reports whether authentication is required by the server.
@@ -365,7 +311,7 @@ func (c *Context) RemoteAddr() net.Addr {
 
 // Mechanism returns the authentication mechanism from the context.
 // If no authentication is set, it returns AuthNone.
-func (c *Context) Mechanism() AuthMach {
+func (c *Context) Mechanism() AuthMech {
 	if c.auth == nil {
 		return AuthNone
 	}
@@ -638,8 +584,8 @@ loop:
 					s.writef("452 4.5.3 Too many recipients")
 				} else {
 					accept := true
-					if s.srv.hasRcptHandler() {
-						accept = s.srv.handleRcpt(s.c, from, match[1])
+					if s.srv.HandlerRcpt != nil {
+						accept = s.srv.HandlerRcpt(s.c, from, match[1])
 					}
 					if accept {
 						to = append(to, match[1])
@@ -698,8 +644,8 @@ loop:
 			}
 
 			// Pass mail on to handler.
-			if s.srv.hasHandler() {
-				err := s.srv.handle(s.c, m)
+			if s.srv.Handler != nil {
+				err := s.srv.Handler(s.c, m)
 				if err != nil {
 					checkErrFormat := regexp.MustCompile(`^([2-5][0-9]{2})[\s\-](.+)$`)
 					if checkErrFormat.MatchString(err.Error()) {
@@ -710,8 +656,8 @@ loop:
 					break
 				}
 				s.writef("250 2.0.0 Ok: queued")
-			} else if s.srv.hasMsgIdHandler() {
-				msgID, err := s.srv.handleMsgId(s.c, m)
+			} else if s.srv.MsgIDHandler != nil {
+				msgID, err := s.srv.MsgIDHandler(s.c, m)
 				if err != nil {
 					checkErrFormat := regexp.MustCompile(`^([2-5][0-9]{2})[\s\-](.+)$`)
 					if checkErrFormat.MatchString(err.Error()) {
@@ -831,7 +777,7 @@ loop:
 				break
 			}
 			// Handle case where AUTH is requested but not configured (and therefore not listed as a service extension).
-			if !s.srv.hasAuthHandler() {
+			if s.srv.AuthHandler == nil {
 				s.writef("502 5.5.1 Command not implemented")
 				break
 			}
@@ -850,14 +796,16 @@ loop:
 
 			// RFC 4954 requires a mechanism parameter.
 			authType, authArgs := s.parseLine(args)
-			if authType == "" {
+			authMach, ok := parseAuthMech(authType)
+
+			if !ok {
 				s.writef("501 5.5.4 Malformed AUTH input (argument required)")
 				break
 			}
 
 			// RFC 4954 requires rejecting unsupported authentication mechanisms with a 504 response.
 			allowedAuth := s.authMechs()
-			if allowed, found := allowedAuth[authType]; !found || !allowed {
+			if allowed, found := allowedAuth[authMach]; !found || !allowed {
 				s.writef("504 5.5.4 Unrecognized authentication type")
 				break
 			}
@@ -865,12 +813,12 @@ loop:
 			// RFC 4954 also specifies that ESMTP code 5.5.4 ("Invalid command arguments") should be returned
 			// when attempting to use an unsupported authentication type.
 			// Many servers return 5.7.4 ("Security features not supported") instead.
-			switch authType {
-			case "PLAIN":
+			switch authMach {
+			case AuthPlain:
 				s.c.authenticated, err = s.handleAuthPlain(authArgs)
-			case "LOGIN":
+			case AuthLogin:
 				s.c.authenticated, err = s.handleAuthLogin(authArgs)
-			case "CRAM-MD5":
+			case AuthCramMD5:
 				s.c.authenticated, err = s.handleAuthCramMD5()
 			}
 
@@ -1002,8 +950,8 @@ func (s *session) makeHeaders(to []string) []byte {
 // Determine allowed authentication mechanisms.
 // RFC 4954 specifies that plaintext authentication mechanisms such as LOGIN and PLAIN require a TLS connection.
 // This can be explicitly overridden e.g. setting s.srv.AuthMechs["LOGIN"] = true.
-func (s *session) authMechs() (mechs map[string]bool) {
-	mechs = map[string]bool{"LOGIN": s.c.tls, "PLAIN": s.c.tls, "CRAM-MD5": true}
+func (s *session) authMechs() (mechs map[AuthMech]bool) {
+	mechs = map[AuthMech]bool{AuthLogin: s.c.tls, AuthPlain: s.c.tls, AuthCramMD5: true}
 
 	for mech := range mechs {
 		allowed, found := s.srv.AuthMechs[mech]
@@ -1032,7 +980,7 @@ func (s *session) makeEHLOResponse() (response string) {
 		var mechs []string
 		for mech, allowed := range s.authMechs() {
 			if allowed {
-				mechs = append(mechs, mech)
+				mechs = append(mechs, mech.String())
 			}
 		}
 		if len(mechs) > 0 {
@@ -1078,9 +1026,7 @@ func (s *session) handleAuthLogin(arg string) (bool, error) {
 	}
 
 	// Validate credentials.
-	authenticated, err := s.srv.handleAuth(s.c)
-
-	return authenticated, err
+	return s.srv.AuthHandler(s.c)
 }
 
 func (s *session) handleAuthPlain(arg string) (bool, error) {
@@ -1112,9 +1058,7 @@ func (s *session) handleAuthPlain(arg string) (bool, error) {
 	}
 
 	// Validate credentials.
-	authenticated, err := s.srv.handleAuth(s.c)
-
-	return authenticated, err
+	return s.srv.AuthHandler(s.c)
 }
 
 func (s *session) handleAuthCramMD5() (bool, error) {
@@ -1149,7 +1093,5 @@ func (s *session) handleAuthCramMD5() (bool, error) {
 	}
 
 	// Validate credentials.
-	authenticated, err := s.srv.handleAuth(s.c)
-
-	return authenticated, err
+	return s.srv.AuthHandler(s.c)
 }

--- a/smtpd.go
+++ b/smtpd.go
@@ -61,8 +61,6 @@ func parseAuthMech(s string) (AuthMech, bool) {
 		return AuthLogin, true
 	case "CRAM-MD5":
 		return AuthCramMD5, true
-	case "NONE":
-		return AuthNone, true
 	default:
 		return AuthNone, false
 	}

--- a/smtpd_test.go
+++ b/smtpd_test.go
@@ -311,10 +311,10 @@ type mockHandler struct {
 	handlerCalled int
 }
 
-func (m *mockHandler) handler(err error) func(c *Context, msg Message) error {
-	return func(c *Context, msg Message) error {
+func (m *mockHandler) handler(err error) func(c *Context, msg Message) (*Response, error) {
+	return func(c *Context, msg Message) (*Response, error) {
 		m.handlerCalled++
-		return err
+		return nil, err
 	}
 }
 


### PR DESCRIPTION
This PR extends the `smtpd` package with a shared session Context, enabling data to be shared between different handlers.

## Motivation:

- The package is lightweight and simple, which is excellent, but it previously lacked a way to share state between handlers.
- Many advanced use cases require sharing data such as authentication details, per-session metadata, or external service instances (e.g., Sentry) across different stages of handling an SMTP session.

## Changes Introduced:

- Introduced a `Context` struct to hold session-specific data, authentication info, and custom key/value pairs.
- Added `*WithCtx` variants for all main handlers:
  - `HandlerWithCtx`
  - `MsgIDHandlerWithCtx`
  - `HandlerRcptWithCtx`
  - `AuthHandlerWithCtx`
- Legacy handlers remain prioritized to preserve backward compatibility.
- The `Context` object allows handlers to share auth data, track metadata, and attach additional information across the session.

## Benefits:

- More control over the handlers